### PR TITLE
MACD 계산 API 추가

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/DashboardController.java
@@ -1,4 +1,24 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller;
 
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.MacdDTO;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.service.CoinMarketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/dashboard")
+@RequiredArgsConstructor
 public class DashboardController {
+    private final CoinMarketService coinMarketService;
+
+    @GetMapping("/{symbol}/macd")
+    public ResponseEntity<MacdDTO> getMacd(@PathVariable("symbol") String symbol) {
+        MacdDTO response = coinMarketService.getMacdForSymbol(symbol);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/response/MacdDTO.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/response/MacdDTO.java
@@ -1,0 +1,13 @@
+package _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MacdDTO {
+    private final double value;
+    private final double signal;
+    private final double histogram;
+    private final String trend;
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketService.java
@@ -1,4 +1,7 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.service;
 
-public class CoinMarketService {
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.MacdDTO;
+
+public interface CoinMarketService {
+    MacdDTO getMacdForSymbol(String symbol);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketServiceImpl.java
@@ -1,4 +1,99 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.service;
 
-public class CoinMarketServiceImpl {
+
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.MacdDTO;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.TickerTestRepository;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerTestEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CoinMarketServiceImpl implements CoinMarketService {
+
+    private final TickerTestRepository tickerTestRepository;
+
+    public MacdDTO getMacdForSymbol(String symbol) {
+        List<Double> prices = getClosingPrices(symbol);
+
+        System.out.println("Closing Prices Count: " + prices.size());
+        System.out.println("Prices: " + prices);
+
+        if (prices.size() < 26) {
+            throw new IllegalArgumentException("데이터 부족: MACD 계산을 위해 최소 26일 이상의 가격 데이터가 필요합니다.");
+        }
+
+        return calculateMACD(prices);
+    }
+
+    private List<Double> getClosingPrices(String symbol) {
+        List<TickerTestEntity> tickers = tickerTestRepository.findByCodeOrderedByUtcDateTime(symbol);
+        return tickers.stream()
+                .map(ticker -> ticker.getTradePrice().doubleValue())
+                .collect(Collectors.toList());
+    }
+
+    private MacdDTO calculateMACD(List<Double> prices) {
+        Collections.reverse(prices);
+
+        // 12일 EMA 계산
+        List<Double> ema12 = calculateEMAList(prices, 12);
+
+        // 26일 EMA 계산
+        List<Double> ema26 = calculateEMAList(prices, 26);
+
+        // MACD Line 계산 (12일 EMA - 26일 EMA)
+        List<Double> macdLine = new ArrayList<>();
+        for (int i = 0; i < ema12.size() && i < ema26.size(); i++) {
+            macdLine.add(ema12.get(i) - ema26.get(i));
+        }
+
+        if (macdLine.size() < 9) {
+            throw new IllegalArgumentException("MACD 데이터 부족: 최소 9개 이상의 MACD 데이터가 필요합니다.");
+        }
+
+        // Signal Line (MACD Line의 9일 EMA)
+        List<Double> signalLine = calculateEMAList(macdLine, 9);
+
+        // 최신 MACD 값
+        double macd = macdLine.get(macdLine.size() - 1);
+        double signal = signalLine.get(signalLine.size() - 1);
+        double histogram = macd - signal;
+        String trend = histogram > 0 ? "RISE" : "FALL";
+
+        return new MacdDTO(macd, signal, histogram, trend);
+    }
+
+    private List<Double> calculateEMAList(List<Double> prices, int period) {
+        List<Double> emaList = new ArrayList<>();
+
+        // 첫 번째 EMA는 해당 기간의 SMA(단순 이동평균)로 계산
+        double sma = 0;
+        for (int i = 0; i < period; i++) {
+            sma += prices.get(i);
+        }
+        sma /= period;
+
+        // 첫 번째 EMA 값 추가
+        emaList.add(sma);
+
+        // EMA 계산 공식: EMA(today) = Price(today) * k + EMA(yesterday) * (1-k)
+        // k = 2/(period+1)
+        double multiplier = 2.0 / (period + 1);
+
+        // 나머지 EMA 계산
+        for (int i = period; i < prices.size(); i++) {
+            double currentPrice = prices.get(i);
+            double previousEma = emaList.get(emaList.size() - 1);
+            double currentEma = (currentPrice * multiplier) + (previousEma * (1 - multiplier));
+            emaList.add(currentEma);
+        }
+
+        return emaList;
+    }
 }


### PR DESCRIPTION
### Description

MACD 계산 API 추가

### Changes Made

- 특정 코인의 MACD 값을 계산하는 API 추가
- 향후 RSI 등 지표 추가하여 대시보드용 통합 API로 확장 예정

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

