### PR TITLE
대시보드 지표 조회 API 추가 및 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ application*.yml
 /node_modules
 
 gradle/wrapper/gradle-wrapper.jar
+
+.DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/DashboardController.java
@@ -1,5 +1,6 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller;
 
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.DashboardResponse;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.ResponseKimchiPremium;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.service.KimchiPremiumService;
 import jakarta.validation.constraints.Min;
@@ -25,9 +26,9 @@ public class DashboardController {
     private final KimchiPremiumService kimchiPremiumService;
 
     @GetMapping("/{coinId}/index")
-    public ResponseEntity<MacdDTO> getDashboardIndicators(@PathVariable("coinId") Long coinId) {
-        MacdDTO macdData = coinMarketService.getMacdForCoin(coinId);
-        return ResponseEntity.ok(macdData);
+    public ResponseEntity<DashboardResponse> getDashboardIndicators(@PathVariable("coinId") Long coinId) {
+        DashboardResponse response = coinMarketService.getDashboardIndicators(coinId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/kimchi")

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/DashboardController.java
@@ -24,10 +24,10 @@ public class DashboardController {
     private final CoinMarketService coinMarketService;
     private final KimchiPremiumService kimchiPremiumService;
 
-    @GetMapping("/{symbol}/macd")
-    public ResponseEntity<MacdDTO> getMacd(@PathVariable("symbol") String symbol) {
-        MacdDTO response = coinMarketService.getMacdForSymbol(symbol);
-        return ResponseEntity.ok(response);
+    @GetMapping("/{coinId}/index")
+    public ResponseEntity<MacdDTO> getDashboardIndicators(@PathVariable("coinId") Long coinId) {
+        MacdDTO macdData = coinMarketService.getMacdForCoin(coinId);
+        return ResponseEntity.ok(macdData);
     }
 
     @GetMapping("/kimchi")

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/response/DashboardResponse.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/response/DashboardResponse.java
@@ -1,0 +1,11 @@
+package _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DashboardResponse {
+    private MacdDTO macd;
+    private RsiDTO rsi;
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/response/RsiDTO.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/controller/response/RsiDTO.java
@@ -1,0 +1,10 @@
+package _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RsiDTO {
+    private double value;
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerTestRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerTestRepository.java
@@ -1,31 +1,9 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository;
 
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerTestEntity;
-import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerTestId;
-import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.jpa.TickerTestJpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
-public class TickerTestRepository {
-    private final TickerTestJpaRepository jpaRepository;
-    private final TickerTestRepositoryImpl repositoryImpl;
-
-    public TickerTestRepository(TickerTestJpaRepository jpaRepository, TickerTestRepositoryImpl repositoryImpl) {
-        this.jpaRepository = jpaRepository;
-        this.repositoryImpl = repositoryImpl;
-    }
-
-    public List<TickerTestEntity> findByCodeOrderedByUtcDateTime(String code) {
-        return repositoryImpl.findByCodeOrderedByUtcDateTime(code);
-    }
-
-    public void save(TickerTestEntity entity) {
-        jpaRepository.save(entity);
-    }
-
-    public void deleteById(TickerTestId id) {
-        jpaRepository.deleteById(id);
-    }
+public interface TickerTestRepository {
+    List<TickerTestEntity> findByCodeOrderedByUtcDateTime(String code);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerTestRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerTestRepository.java
@@ -5,5 +5,5 @@ import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.Ti
 import java.util.List;
 
 public interface TickerTestRepository {
-    List<TickerTestEntity> findByCodeOrderedByUtcDateTime(String code);
+    List<TickerTestEntity> findByCoinIdOrderedByUtcDateTime(Long coinId);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerTestRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerTestRepositoryImpl.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class TickerTestRepositoryImpl {
+public class TickerTestRepositoryImpl implements TickerTestRepository {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerTestRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerTestRepositoryImpl.java
@@ -1,5 +1,6 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository;
 
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.QCoinEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.QTickerTestEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerTestEntity;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -14,12 +15,14 @@ public class TickerTestRepositoryImpl implements TickerTestRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<TickerTestEntity> findByCodeOrderedByUtcDateTime(String code) {
+    public List<TickerTestEntity> findByCoinIdOrderedByUtcDateTime(Long coinId) {
         QTickerTestEntity ticker = QTickerTestEntity.tickerTestEntity;
+        QCoinEntity coin = QCoinEntity.coinEntity;
 
         return queryFactory
                 .selectFrom(ticker)
-                .where(ticker.id.code.eq(code))
+                .join(coin).on(ticker.id.code.substring(4).eq(coin.symbol)) // "KRW-" 제거 후 조인
+                .where(coin.coinId.eq(coinId))
                 .orderBy(ticker.id.utcDateTime.asc())
                 .fetch();
     }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/jpa/TickerTestJpaRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/jpa/TickerTestJpaRepository.java
@@ -7,6 +7,5 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface TickerTestJpaRepository extends JpaRepository<TickerTestEntity, TickerTestId> {
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketService.java
@@ -1,7 +1,8 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.service;
 
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.DashboardResponse;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.MacdDTO;
 
 public interface CoinMarketService {
-    MacdDTO getMacdForCoin(Long coinId);
+    DashboardResponse getDashboardIndicators(Long coinId);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketService.java
@@ -3,5 +3,5 @@ package _1danhebojo.coalarm.coalarm_service.domain.dashboard.service;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.MacdDTO;
 
 public interface CoinMarketService {
-    MacdDTO getMacdForSymbol(String symbol);
+    MacdDTO getMacdForCoin(Long coinId);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinMarketServiceImpl.java
@@ -18,11 +18,9 @@ public class CoinMarketServiceImpl implements CoinMarketService {
 
     private final TickerTestRepository tickerTestRepository;
 
-    public MacdDTO getMacdForSymbol(String symbol) {
-        List<Double> prices = getClosingPrices(symbol);
-
-        System.out.println("Closing Prices Count: " + prices.size());
-        System.out.println("Prices: " + prices);
+    @Override
+    public MacdDTO getMacdForCoin(Long coinId) {
+        List<Double> prices = getClosingPrices(coinId);
 
         if (prices.size() < 26) {
             throw new IllegalArgumentException("데이터 부족: MACD 계산을 위해 최소 26일 이상의 가격 데이터가 필요합니다.");
@@ -31,8 +29,10 @@ public class CoinMarketServiceImpl implements CoinMarketService {
         return calculateMACD(prices);
     }
 
-    private List<Double> getClosingPrices(String symbol) {
-        List<TickerTestEntity> tickers = tickerTestRepository.findByCodeOrderedByUtcDateTime(symbol);
+    private List<Double> getClosingPrices(Long coinId) {
+        List<TickerTestEntity> tickers = tickerTestRepository.findByCoinIdOrderedByUtcDateTime(coinId);
+        System.out.println("Fetched Data Count: " + tickers.size());
+        System.out.println("Fetched Data: " + tickers);
         return tickers.stream()
                 .map(ticker -> ticker.getTradePrice().doubleValue())
                 .collect(Collectors.toList());


### PR DESCRIPTION
### Description

- 기존 symbol로 MACD를 조회하던 API를 coinId로 조회하게 수정
- RSI 지수 계산 로직 추가
- MACD 조회 API를 대시보드 지표 조회 API로 수정 (현재 MACD, RSI만 응답에 포함됨. 공매수/공매도 및 코인정보 dto 추가 예정)

### Related Issues

- closes #14

### Changes Made

1. TickerTestRepository 클래스를 인터페이스로 수정
2. RSI 계산 코드 추가
3. MACD 조회 API를 통합 지표 조회 API로 확장

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.
