### PR TITLE
Spring Security 인증/인가 예외 처리 및 로그아웃/회원탈퇴 API 구현

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/auth/entity/JwtBlacklistEntity.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/auth/entity/JwtBlacklistEntity.java
@@ -1,0 +1,35 @@
+package _1danhebojo.coalarm.coalarm_service.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@Table(name = "jwt_blacklist")
+@AllArgsConstructor
+public class JwtBlacklistEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+
+    public static JwtBlacklistEntity of(String token, Instant expiryDate) {
+        return JwtBlacklistEntity.builder()
+                .token(token)
+                .expiryDate(expiryDate)
+                .build();
+    }
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/auth/repository/JwtBlacklistJpaRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/auth/repository/JwtBlacklistJpaRepository.java
@@ -1,0 +1,12 @@
+package _1danhebojo.coalarm.coalarm_service.domain.auth.repository;
+
+import _1danhebojo.coalarm.coalarm_service.domain.auth.entity.JwtBlacklistEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface JwtBlacklistJpaRepository extends JpaRepository<JwtBlacklistEntity, Long> {
+    Optional<JwtBlacklistEntity> findByToken(String token);
+    void deleteByExpiryDateBefore(Instant now);
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/auth/service/JwtBlacklistService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/auth/service/JwtBlacklistService.java
@@ -1,0 +1,11 @@
+package _1danhebojo.coalarm.coalarm_service.domain.auth.service;
+
+import java.time.Instant;
+
+public interface JwtBlacklistService {
+    void addToBlacklist(String token, Instant expiryDate);
+
+    boolean isBlacklisted(String token);
+
+    void removeExpiredTokens();
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/auth/service/JwtBlacklistServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/auth/service/JwtBlacklistServiceImpl.java
@@ -1,0 +1,33 @@
+package _1danhebojo.coalarm.coalarm_service.domain.auth.service;
+
+import _1danhebojo.coalarm.coalarm_service.domain.auth.entity.JwtBlacklistEntity;
+import _1danhebojo.coalarm.coalarm_service.domain.auth.repository.JwtBlacklistJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class JwtBlacklistServiceImpl implements JwtBlacklistService {
+
+    private final JwtBlacklistJpaRepository jwtBlacklistJpaRepository;
+
+    @Override
+    public void addToBlacklist(String token, Instant expiryDate) {
+        JwtBlacklistEntity entity = JwtBlacklistEntity.of(token, expiryDate);
+        jwtBlacklistJpaRepository.save(entity);
+    }
+
+    @Override
+    public boolean isBlacklisted(String token) {
+        return jwtBlacklistJpaRepository.findByToken(token).isPresent();
+    }
+
+    @Override
+    @Scheduled(cron = "0 0 * * * ?") // 만료된 토큰을 매 시간 디비에서 삭제
+    public void removeExpiredTokens() {
+        jwtBlacklistJpaRepository.deleteByExpiryDateBefore(Instant.now());
+    }
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/controller/UserController.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/controller/UserController.java
@@ -1,14 +1,8 @@
 package _1danhebojo.coalarm.coalarm_service.domain.user.controller;
 
-import _1danhebojo.coalarm.coalarm_service.domain.auth.service.JwtBlacklistService;
-import _1danhebojo.coalarm.coalarm_service.domain.user.controller.request.UserUpdateRequest;
 import _1danhebojo.coalarm.coalarm_service.domain.user.controller.response.UserDTO;
-import _1danhebojo.coalarm.coalarm_service.domain.user.service.RefreshTokenService;
 import _1danhebojo.coalarm.coalarm_service.domain.user.service.UserService;
-import _1danhebojo.coalarm.coalarm_service.global.api.ApiException;
-import _1danhebojo.coalarm.coalarm_service.global.api.AppHttpStatus;
 import _1danhebojo.coalarm.coalarm_service.global.api.BaseResponse;
-import _1danhebojo.coalarm.coalarm_service.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,81 +14,43 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.Instant;
 
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserController {
+
     private final UserService userService;
-    private final RefreshTokenService refreshTokenService;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final JwtBlacklistService jwtBlacklistService;
 
-
-    @GetMapping()
+    // 회원 정보 불러오기
+    @GetMapping
     public ResponseEntity<BaseResponse<UserDTO>> getMyInfo(@AuthenticationPrincipal UserDetails userDetails) {
-        String kakaoId = userDetails.getUsername();
-        UserDTO userDTO = userService.findByKakaoId(kakaoId);
+        UserDTO userDTO = userService.getMyInfo(userDetails);
         return ResponseEntity.ok(BaseResponse.success(userDTO));
     }
 
-    // NOTE: 프로필 수정
-    @PatchMapping()
+    // 회원 프로필 수정 (닉네임, 프로필 사진)
+    @PatchMapping
     public ResponseEntity<BaseResponse<Long>> updateUserInfo(@AuthenticationPrincipal UserDetails userDetails,
-         @RequestPart(value = "nickname", required = false) String nickname,
-         @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
-
-        String kakaoId = userDetails.getUsername();
-        UserUpdateRequest request = UserUpdateRequest.of(nickname, profileImage);
-        UserDTO userDTO = userService.updateUser(kakaoId, request);
-
-        return ResponseEntity.ok(BaseResponse.success(userDTO.getUserId()));
+                                                             @RequestPart(value = "nickname", required = false) String nickname,
+                                                             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+        Long userId = userService.updateUser(userDetails, nickname, profileImage);
+        return ResponseEntity.ok(BaseResponse.success(userId));
     }
 
+    // 로그아웃
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<Void>> logout(@AuthenticationPrincipal UserDetails userDetails,
                                                      @RequestHeader("Authorization") String authorizationHeader) {
-        if (userDetails == null) {
-            throw new ApiException(AppHttpStatus.UNAUTHORIZED);
-        }
-
-        String kakaoId = userDetails.getUsername();
-        Long userId = userService.findByKakaoId(kakaoId).getUserId();
-
-        // 리프레시 토큰 삭제
-        refreshTokenService.deleteRefreshToken(userId);
-
-        // 액세스 토큰을 블랙리스트에 추가
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            String accessToken = authorizationHeader.substring(7).trim();
-            Instant expiryInstant = jwtTokenProvider.getExpirationInstant(accessToken);
-
-            // 블랙리스트에 등록
-            if (expiryInstant != null) {
-                jwtBlacklistService.addToBlacklist(accessToken, expiryInstant);
-            }
-        }
-
+        userService.logout(userDetails, authorizationHeader);
         return ResponseEntity.ok(BaseResponse.success());
     }
 
+    // 회원 탈퇴
     @DeleteMapping
-    public ResponseEntity<BaseResponse<Void>> withdraw(
-            @AuthenticationPrincipal UserDetails userDetails,
-            @RequestHeader("Authorization") String authorizationHeader) {
-
-        if (userDetails == null) {
-            throw new ApiException(AppHttpStatus.UNAUTHORIZED);
-        }
-
-        String kakaoId = userDetails.getUsername();
-        Long userId = userService.findByKakaoId(kakaoId).getUserId();
-
-        // 회원 탈퇴 서비스 실행 (리프레시 토큰 삭제, 블랙리스트 추가, 유저 삭제 포함)
-        userService.deleteUser(userId, authorizationHeader);
-
-
+    public ResponseEntity<BaseResponse<Void>> withdraw(@AuthenticationPrincipal UserDetails userDetails,
+                                                       @RequestHeader("Authorization") String authorizationHeader) {
+        userService.deleteUser(userDetails, authorizationHeader);
         return ResponseEntity.ok(BaseResponse.success());
     }
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/controller/UserController.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/controller/UserController.java
@@ -78,4 +78,23 @@ public class UserController {
 
         return ResponseEntity.ok(BaseResponse.success());
     }
+
+    @DeleteMapping
+    public ResponseEntity<BaseResponse<Void>> withdraw(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestHeader("Authorization") String authorizationHeader) {
+
+        if (userDetails == null) {
+            throw new ApiException(AppHttpStatus.UNAUTHORIZED);
+        }
+
+        String kakaoId = userDetails.getUsername();
+        Long userId = userService.findByKakaoId(kakaoId).getUserId();
+
+        // 회원 탈퇴 서비스 실행 (리프레시 토큰 삭제, 블랙리스트 추가, 유저 삭제 포함)
+        userService.deleteUser(userId, authorizationHeader);
+
+
+        return ResponseEntity.ok(BaseResponse.success());
+    }
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/repository/UserRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface UserRepository {
     Optional<UserEntity> findByKakaoId(String kakaoId);
     UserEntity save(UserEntity userEntity);
+    Optional<UserEntity> findById(Long userId);
+    void delete(UserEntity userEntity);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/repository/UserRepositoryImpl.java
@@ -18,7 +18,17 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public Optional<UserEntity> findById(Long userId) {
+        return userJpaRepository.findById(userId);
+    }
+
+    @Override
     public UserEntity save(UserEntity user) {
         return userJpaRepository.save(user);
+    }
+
+    @Override
+    public void delete(UserEntity userEntity) {
+        userJpaRepository.delete(userEntity);
     }
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/repository/jpa/UserJpaRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/repository/jpa/UserJpaRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByKakaoId(String kakaoId);
+    Optional<UserEntity> findById(Long userId);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/service/UserService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/service/UserService.java
@@ -2,10 +2,14 @@ package _1danhebojo.coalarm.coalarm_service.domain.user.service;
 
 import _1danhebojo.coalarm.coalarm_service.domain.user.controller.request.UserUpdateRequest;
 import _1danhebojo.coalarm.coalarm_service.domain.user.controller.response.UserDTO;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
     UserDTO registerOrLogin(String kakaoId, String email);
     UserDTO findByKakaoId(String kakaoId);
-    UserDTO updateUser(String kakaoId, UserUpdateRequest request);
-    void deleteUser(Long userId, String accessToken);
+    Long updateUser(UserDetails userDetails, String nickname, MultipartFile profileImage);
+    UserDTO getMyInfo(UserDetails userDetails);
+    void logout(UserDetails userDetails, String authorizationHeader);
+    void deleteUser(UserDetails userDetails, String authorizationHeader);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/service/UserService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/service/UserService.java
@@ -7,4 +7,5 @@ public interface UserService {
     UserDTO registerOrLogin(String kakaoId, String email);
     UserDTO findByKakaoId(String kakaoId);
     UserDTO updateUser(String kakaoId, UserUpdateRequest request);
+    void deleteUser(Long userId, String accessToken);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/service/UserServiceImpl.java
@@ -1,11 +1,9 @@
 package _1danhebojo.coalarm.coalarm_service.domain.user.service;
 
 import _1danhebojo.coalarm.coalarm_service.domain.auth.service.JwtBlacklistService;
-import _1danhebojo.coalarm.coalarm_service.domain.user.controller.request.UserUpdateRequest;
 import _1danhebojo.coalarm.coalarm_service.domain.user.controller.response.UserDTO;
 import _1danhebojo.coalarm.coalarm_service.domain.user.repository.entity.UserEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.user.repository.UserRepository;
-import _1danhebojo.coalarm.coalarm_service.domain.user.repository.jpa.UserJpaRepository;
 import _1danhebojo.coalarm.coalarm_service.domain.user.util.NicknameGenerator;
 import _1danhebojo.coalarm.coalarm_service.global.api.ApiException;
 import _1danhebojo.coalarm.coalarm_service.global.api.AppHttpStatus;
@@ -13,6 +11,7 @@ import _1danhebojo.coalarm.coalarm_service.global.security.JwtTokenProvider;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,6 +28,14 @@ public class UserServiceImpl implements UserService {
     private final RefreshTokenService refreshTokenService;
     private final JwtBlacklistService jwtBlacklistService;
     private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public UserDTO getMyInfo(UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new ApiException(AppHttpStatus.UNAUTHORIZED);
+        }
+        return findByKakaoId(userDetails.getUsername());
+    }
 
     @Override
     @Transactional
@@ -52,6 +59,25 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
+    public void logout(UserDetails userDetails, String authorizationHeader) {
+        if (userDetails == null) {
+            throw new ApiException(AppHttpStatus.UNAUTHORIZED);
+        }
+
+        Long userId = findByKakaoId(userDetails.getUsername()).getUserId();
+        refreshTokenService.deleteRefreshToken(userId);
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String accessToken = authorizationHeader.substring(7).trim();
+            Instant expiryInstant = jwtTokenProvider.getExpirationInstant(accessToken);
+            if (expiryInstant != null) {
+                jwtBlacklistService.addToBlacklist(accessToken, expiryInstant);
+            }
+        }
+    }
+
+    @Override
     public UserDTO findByKakaoId(String kakaoId) {
         UserEntity user = userRepository.findByKakaoId(kakaoId)
                 .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND));
@@ -60,35 +86,27 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    @Transactional
-    public UserDTO updateUser(String kakaoId, UserUpdateRequest request) {
-        UserEntity user = userRepository.findByKakaoId(kakaoId)
+    public Long updateUser(UserDetails userDetails, String nickname, MultipartFile profileImage) {
+        UserEntity user = userRepository.findByKakaoId(userDetails.getUsername())
                 .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_USER));
 
         // 닉네임 업데이트
-        String nickname = request.getNickname();
         if (nickname != null && !nickname.isEmpty()) {
             validateNickname(nickname);
             user.updateNickname(nickname);
         }
 
         // 프로필 이미지 업데이트
-        MultipartFile profileImage = request.getProfileImage();
         if (profileImage != null && !profileImage.isEmpty()) {
-            // 기존 이미지가 있으면 삭제
-            String currentProfileImage = user.getProfileImg();
-            if (currentProfileImage != null && !currentProfileImage.isEmpty()) {
-                s3Service.deleteImage(currentProfileImage);
+            if (user.getProfileImg() != null) {
+                s3Service.deleteImage(user.getProfileImg());
             }
-
-            // 새 이미지 업로드
             String imageUrl = s3Service.uploadImage(profileImage);
             user.updateProfileImage(imageUrl);
         }
 
-        // 변경된 엔티티 저장
-        UserEntity updatedUser = userRepository.save(user);
-        return UserDTO.fromEntity(updatedUser);
+        userRepository.save(user);
+        return user.getUserId();
     }
 
     private void validateNickname(String nickname) {
@@ -99,8 +117,13 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void deleteUser(Long userId, String authorizationHeader) {
-        UserEntity user = userRepository.findById(userId)
+    @Transactional
+    public void deleteUser(UserDetails userDetails, String authorizationHeader) {
+        if (userDetails == null) {
+            throw new ApiException(AppHttpStatus.UNAUTHORIZED);
+        }
+
+        UserEntity user = userRepository.findByKakaoId(userDetails.getUsername())
                 .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_USER));
 
         // 프로필 이미지 삭제
@@ -109,7 +132,7 @@ public class UserServiceImpl implements UserService {
         }
 
         // 리프레시 토큰 삭제
-        refreshTokenService.deleteRefreshToken(userId);
+        refreshTokenService.deleteRefreshToken(user.getUserId());
 
         // 액세스 토큰 블랙리스트 추가
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/api/AppHttpStatus.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/api/AppHttpStatus.java
@@ -48,7 +48,7 @@ public enum AppHttpStatus {
      */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에 에러가 발생했습니다."),
     IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"S3에 이미지 업로드중 에러가 발생했습니다."),
-    IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3의 이미지 삭제중 에러가 발생했습니다.");
+    IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3의 이미지 삭제중 에러가 발생했습니다."),
 
     /**
      * 502: 게이트웨이, 프록시 역할을 하는 서버가 다른 서버로부터 유효하지 않은 응답을 받았을 때

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,42 @@
+package _1danhebojo.coalarm.coalarm_service.global.security;
+
+import _1danhebojo.coalarm.coalarm_service.global.api.AppHttpStatus;
+import _1danhebojo.coalarm.coalarm_service.global.api.BaseResponse;
+import _1danhebojo.coalarm.coalarm_service.global.api.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
+            throws IOException, ServletException {
+
+        // 인가 실패 시 응답 설정
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        // JSON 응답 포맷 설정
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(AppHttpStatus.FORBIDDEN.getHttpStatus().value())
+                .message(AppHttpStatus.FORBIDDEN.getMessage())
+                .build();
+
+        BaseResponse<Void> baseResponse = BaseResponse.error(errorResponse);
+
+        response.getWriter().write(objectMapper.writeValueAsString(baseResponse));
+    }
+
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package _1danhebojo.coalarm.coalarm_service.global.security;
+
+import _1danhebojo.coalarm.coalarm_service.global.api.AppHttpStatus;
+import _1danhebojo.coalarm.coalarm_service.global.api.BaseResponse;
+import _1danhebojo.coalarm.coalarm_service.global.api.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+        throws IOException,ServletException {
+
+        // 인증 실패 시 HTTP 응답 설정
+        response.setContentType(("application/json;charset=UTF-8"));
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        // 에러 응답 객체 생성
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(AppHttpStatus.UNAUTHORIZED.getHttpStatus().value())
+                .message(AppHttpStatus.UNAUTHORIZED.getMessage())
+                .build();
+
+        BaseResponse<Void> baseResponse = BaseResponse.error(errorResponse);
+
+        try {
+            // 응답을 JSON으로 변환하여 츌력
+            response.getWriter().write(objectMapper.writeValueAsString(baseResponse));
+        } catch (JsonProcessingException e) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "JSON 변환 중 오류 발생");
+        } catch (java.io.IOException e) {
+            throw new ServletException("응답 스트림 처리 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/JwtTokenProvider.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/JwtTokenProvider.java
@@ -12,6 +12,7 @@ import io.jsonwebtoken.security.Keys;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.time.Instant;
 import java.util.Date;
 
 @Component
@@ -73,5 +74,22 @@ public class JwtTokenProvider {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    /**
+     * JWT 토큰에서 만료 시간 추출
+     */
+    public Instant getExpirationInstant(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration()
+                    .toInstant();
+        } catch (JwtException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/SecurityConfig.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/SecurityConfig.java
@@ -1,9 +1,9 @@
 package _1danhebojo.coalarm.coalarm_service.global.security;
 
+import _1danhebojo.coalarm.coalarm_service.domain.auth.service.JwtBlacklistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -16,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtBlacklistService jwtBlacklistService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomAuthenticationEntryPoint customAuthenticationEntryPoint, CustomAccessDeniedHandler customAccessDeniedHandler) throws Exception {
@@ -30,7 +31,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(customAuthenticationEntryPoint) // 인증 실패 처리
                         .accessDeniedHandler(customAccessDeniedHandler) // 권한 부족(403) 처리
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, jwtBlacklistService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/SecurityConfig.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/security/SecurityConfig.java
@@ -18,13 +18,17 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomAuthenticationEntryPoint customAuthenticationEntryPoint, CustomAccessDeniedHandler customAccessDeniedHandler) throws Exception {
         http
                 .csrf(csrf -> csrf.disable()) // CSRF 보호 비활성화
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 X
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/oauth/kakao/**").permitAll()// ✅ 카카오 로그인 API 인증 없이 허용
+                        .requestMatchers("/oauth/kakao/**").permitAll()// 카카오 로그인 API 인증 없이 허용
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint) // 인증 실패 처리
+                        .accessDeniedHandler(customAccessDeniedHandler) // 권한 부족(403) 처리
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

Spring Security의 인증/인가 예외 처리를 추가하고, 로그아웃 API에 JWT 블랙리스트 로직을 추가하였습니다.
또한 회원 탈퇴 API를 구현하고 UserController의 비즈니스 로직을 서비스 레이어르 이동했습니다.

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. 스프링 시큐리티 예외 처리 추가 (`CustomAuthenticationEntryPoint`, `CustomAccessDeniedHandler`)
2. JWT 블랙리스트 기반 로그아웃 기능 구현
  - `JwtBlacklistEntity` 및 관련 리포, 서비스 추가
  - 블랙리스트를 활용해 로그아웃 시 토큰 무효화
3. 회원 탈퇴 API 추가
  - 회원 탈퇴 시 리프레시 토큰 삭제 및 액세스 토큰 블랙리스트 처리
  - 추후 유저와 관련된 알람 데이터 삭제 로직 추가 필요
4. UserController의 비즈니스 로직 서비스 레이어로 이동

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

