### PR TITLE
feat: 여러 코인 검색이 가능하도록 API 수정하고 에러 처리 추가

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/controller/CoinController.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/controller/CoinController.java
@@ -57,7 +57,7 @@ public class CoinController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<BaseResponse<CoinDTO>> searchCoins(@RequestParam("term") String term) {
+    public ResponseEntity<BaseResponse<List<CoinDTO>>> searchCoins(@RequestParam("term") String term) {
         return ResponseEntity.ok(BaseResponse.success(
                 coinService.searchCoinByNameOrSymbol(term)
         ));

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/repository/jpa/CoinJpaRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/repository/jpa/CoinJpaRepository.java
@@ -3,11 +3,12 @@ package _1danhebojo.coalarm.coalarm_service.domain.coin.repository.jpa;
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.entity.CoinEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CoinJpaRepository extends JpaRepository<CoinEntity,Long> {
     Optional<CoinEntity> findBySymbol(String symbol);
     Optional<CoinEntity> findByCoinId(Long coinId);
 
-    Optional<CoinEntity> findByNameContainingIgnoreCaseOrSymbolContainingIgnoreCase(String Start_term, String End_term);
+    List<CoinEntity> findByNameContainingIgnoreCaseOrSymbolContainingIgnoreCase(String searchTerm, String searchTerm2);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinService.java
@@ -10,5 +10,5 @@ public interface CoinService {
     List<CoinDTO> getMyAlertCoins(Long userId);
     OffsetResponse<CoinDTO> getCoinsWithPaging(Integer offset, Integer limit);
     CoinDTO getCoinById(Long coinId);
-    CoinDTO searchCoinByNameOrSymbol(String term);
+    List<CoinDTO> searchCoinByNameOrSymbol(String term);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinServiceImpl.java
@@ -93,9 +93,22 @@ public class CoinServiceImpl implements CoinService {
 
     @Override
     @Transactional(readOnly = true)
-    public CoinDTO searchCoinByNameOrSymbol(String term) {
-        CoinEntity coin = coinJpaRepository.findByNameContainingIgnoreCaseOrSymbolContainingIgnoreCase(term, term)
-                .orElseThrow(() -> new EntityNotFoundException("검색어와 일치하는 코인을 찾을 수 없습니다: " + term));
-        return new CoinDTO(coin);
+    public List<CoinDTO> searchCoinByNameOrSymbol(String term) {
+        if (term == null || term.trim().isEmpty()) {
+            throw new ApiException(AppHttpStatus.EMPTY_SEARCH_TERM);
+        }
+
+        // 검색 수행
+        List<CoinEntity> coins = coinJpaRepository.findByNameContainingIgnoreCaseOrSymbolContainingIgnoreCase(term, term);
+
+        // 검색 결과가 없는 경우 처리
+        if (coins.isEmpty()) {
+            throw new ApiException(AppHttpStatus.NO_SEARCH_RESULTS);
+        }
+
+        // 엔티티 목록을 DTO 목록으로 변환
+        return coins.stream()
+                .map(CoinDTO::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/api/AppHttpStatus.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/api/AppHttpStatus.java
@@ -22,6 +22,8 @@ public enum AppHttpStatus {
     INVALID_LIMIT(HttpStatus.BAD_REQUEST, "한 페이지당 항목 수는 1 이상이어야 합니다."),
     INVALID_COIN_ID(HttpStatus.BAD_REQUEST, "코인 ID는 1 이상이어야 합니다."),
     INVALID_OAUTH_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth 타입입니다."),
+    EMPTY_SEARCH_TERM(HttpStatus.BAD_REQUEST, "검색어를 입력해주세요."),
+    NO_SEARCH_RESULTS(HttpStatus.NOT_FOUND, "검색 결과가 없습니다."),
 
 
     /**


### PR DESCRIPTION
### Description

코인 검색 시 하나의 결과만 반환하던 기존 방식에서, 여러 결과를 반환할 수 있도록 API를 수정했습니다.
또한 검색어가 비어 있거나 결과가 없을 경우 사용자에게 명확한 에러 메시지를 전달하도록 예외 처리를 추가했습니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. /search API 응답을 CoinDTO 단일 객체에서 List<CoinDTO>로 변경
2. CoinJpaRepository의 쿼리 메서드를 Optional → List 반환형으로 수정
3. 검색어가 비어 있거나 결과가 없는 경우 예외 처리 (EMPTY_SEARCH_TERM, NO_SEARCH_RESULTS)

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

