### PR TITLE
fix: 코인 검색 결과 없을 때 404 대신 빈 배열 반환

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -103,7 +104,7 @@ public class CoinServiceImpl implements CoinService {
 
         // 검색 결과가 없는 경우 처리
         if (coins.isEmpty()) {
-            throw new ApiException(AppHttpStatus.NO_SEARCH_RESULTS);
+            return Collections.emptyList();
         }
 
         // 엔티티 목록을 DTO 목록으로 변환

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/api/AppHttpStatus.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/api/AppHttpStatus.java
@@ -23,7 +23,6 @@ public enum AppHttpStatus {
     INVALID_COIN_ID(HttpStatus.BAD_REQUEST, "코인 ID는 1 이상이어야 합니다."),
     INVALID_OAUTH_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth 타입입니다."),
     EMPTY_SEARCH_TERM(HttpStatus.BAD_REQUEST, "검색어를 입력해주세요."),
-    NO_SEARCH_RESULTS(HttpStatus.NOT_FOUND, "검색 결과가 없습니다."),
 
 
     /**


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

기존에는 검색 결과가 없을 경우 ApiException(AppHttpStatus.NO_SEARCH_RESULTS)를 발생시켰으나, 이는 프론트엔드에서 불필요한 404 에러 로그를 발생시킴
따라서 검색 결과가 없을 경우에도 빈 배열을 반환하도록 처리함

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. searchCoinByNameOrSymbol() 로직 수정 -> 결과가 없으면 Collections.emptyList() 반환
2. 더 이상 쓰이지 않는 AppHttpStatus의 NO_SEARCH_RESULTS 삭제

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

