### PR TITLE
feat: 코인 검색 시 최신 가격 포함된 CoinWithPriceDTO 반환 기능 추가

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/controller/CoinController.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/controller/CoinController.java
@@ -1,5 +1,6 @@
 package _1danhebojo.coalarm.coalarm_service.domain.coin.controller;
 
+import _1danhebojo.coalarm.coalarm_service.domain.coin.controller.response.CoinWithPriceDTO;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.CoinDTO;
 import _1danhebojo.coalarm.coalarm_service.domain.coin.service.CoinService;
 import _1danhebojo.coalarm.coalarm_service.domain.user.service.AuthService;
@@ -57,9 +58,9 @@ public class CoinController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<BaseResponse<List<CoinDTO>>> searchCoins(@RequestParam("term") String term) {
+    public ResponseEntity<BaseResponse<List<CoinWithPriceDTO>>> searchCoins(@RequestParam("term") String term) {
         return ResponseEntity.ok(BaseResponse.success(
-                coinService.searchCoinByNameOrSymbol(term)
+                coinService.searchCoinWithPrice(term)
         ));
     }
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/controller/response/CoinWithPriceDTO.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/controller/response/CoinWithPriceDTO.java
@@ -1,0 +1,21 @@
+package _1danhebojo.coalarm.coalarm_service.domain.coin.controller.response;
+
+import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.entity.CoinEntity;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class CoinWithPriceDTO {
+    private final Long coinId;
+    private final String name;
+    private final String symbol;
+    private final BigDecimal price;
+
+    public CoinWithPriceDTO(CoinEntity coin, BigDecimal price) {
+        this.coinId = coin.getCoinId();
+        this.name = coin.getName();
+        this.symbol = coin.getSymbol();
+        this.price = price;
+    }
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinService.java
@@ -1,5 +1,6 @@
 package _1danhebojo.coalarm.coalarm_service.domain.coin.service;
 
+import _1danhebojo.coalarm.coalarm_service.domain.coin.controller.response.CoinWithPriceDTO;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.CoinDTO;
 import _1danhebojo.coalarm.coalarm_service.global.api.OffsetResponse;
 
@@ -11,4 +12,5 @@ public interface CoinService {
     OffsetResponse<CoinDTO> getCoinsWithPaging(Integer offset, Integer limit);
     CoinDTO getCoinById(Long coinId);
     List<CoinDTO> searchCoinByNameOrSymbol(String term);
+    List<CoinWithPriceDTO> searchCoinWithPrice(String term);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/service/CoinServiceImpl.java
@@ -1,19 +1,22 @@
 package _1danhebojo.coalarm.coalarm_service.domain.coin.service;
 
+import _1danhebojo.coalarm.coalarm_service.domain.coin.controller.response.CoinWithPriceDTO;
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.CoinRepository;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.CoinDTO;
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.entity.CoinEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.jpa.CoinJpaRepository;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.TickerRepository;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerEntity;
 import _1danhebojo.coalarm.coalarm_service.global.api.ApiException;
 import _1danhebojo.coalarm.coalarm_service.global.api.AppHttpStatus;
 import _1danhebojo.coalarm.coalarm_service.global.api.OffsetResponse;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,6 +28,8 @@ public class CoinServiceImpl implements CoinService {
 
     private final CoinJpaRepository coinJpaRepository;
     private final CoinRepository coinRepository;
+    private final TickerRepository tickerRepository;
+
     @Override
     @Transactional(readOnly = true)
     public List<CoinDTO> getAllCoins() {
@@ -112,4 +117,32 @@ public class CoinServiceImpl implements CoinService {
                 .map(CoinDTO::new)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CoinWithPriceDTO> searchCoinWithPrice(String term) {
+        if (term == null || term.trim().isEmpty()) {
+            throw new ApiException(AppHttpStatus.EMPTY_SEARCH_TERM);
+        }
+
+        List<CoinEntity> coins = coinJpaRepository
+                .findByNameContainingIgnoreCaseOrSymbolContainingIgnoreCase(term, term);
+
+        if (coins.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return coins.stream()
+                .map(coin -> {
+                    // 최신 가격 가져오기
+                    BigDecimal price = tickerRepository
+                            .findLatestBySymbol(coin.getSymbol())
+                            .map(TickerEntity::getLast)
+                            .orElse(null);
+
+                    return new CoinWithPriceDTO(coin, price);
+                })
+                .toList();
+    }
+
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface TickerRepository {
     List<TickerEntity> findByCoinIdOrderedByUtcDateTime(Long coinId);
+    Optional<TickerEntity> findLatestBySymbol(String symbol);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -43,4 +44,16 @@ public class TickerRepositoryImpl implements TickerRepository{
                 .fetch();
     }
 
+    @Override
+    public Optional<TickerEntity> findLatestBySymbol(String symbol) {
+        QTickerEntity ticker = QTickerEntity.tickerEntity;
+
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(ticker)
+                        .where(ticker.id.symbol.startsWith(symbol + "/"))
+                        .orderBy(ticker.id.timestamp.desc()) // 최신 순으로 정렬
+                        .fetchFirst()
+        );
+    }
 }


### PR DESCRIPTION
### Description

기존 /search 엔드포인트에서 반환하던 CoinDTO 대신, 각 코인의 최신 가격 정보를 포함한 CoinWithPriceDTO로 응답 수정


### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. CoinWithPriceDTO 생성 및 필드 정의 (coinId, name, symbol, price)
2. CoinServiceImpl에 searchCoinWithPrice(String term) 메서드 추가
3. CoinController의 /search 엔드포인트가 CoinWithPriceDTO 리스트를 반환하도록 변경
4. TickerRepository에 findLatestBySymbol(String symbol) 메서드 구현

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

