### PR TITLE
refactor: 알람 히스토리 조회 수정

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepositoryImpl.java
@@ -26,12 +26,7 @@ public class AlertHistoryRepositoryImpl {
 
     @Transactional
     public Page<AlertHistory> findAlertHistoryByFilter(Long userId, Pageable pageable) {
-        List<AlertHistory> alertHistories = alertHistoryJpaRepository.findByUserId(userId);
-
-        int start = (int) pageable.getOffset();
-        int end = Math.min((start + pageable.getPageSize()), alertHistories.size());
-
-        return new PageImpl<>(alertHistories.subList(start, end), pageable, alertHistories.size());
+        return alertHistoryJpaRepository.findByUserId(userId, pageable);
     }
 
     @Transactional

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/jpa/AlertHistoryJpaRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/jpa/AlertHistoryJpaRepository.java
@@ -1,6 +1,8 @@
 package _1danhebojo.coalarm.coalarm_service.domain.alert.repository.jpa;
 
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.AlertHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,11 +15,14 @@ import java.util.List;
 public interface AlertHistoryJpaRepository extends JpaRepository<AlertHistory, Long> {
 
     // alert, coin 정보를 한 번에 가져오도록 fetch join 설정
-    @Query("SELECT ah FROM AlertHistory ah " +
-            "JOIN FETCH ah.alert a " +
-            "JOIN FETCH a.coin c " + // Coin 정보까지 함께 가져오기
-            "WHERE ah.user.userId = :userId")
-    List<AlertHistory> findByUserId(@Param("userId") Long userId);
+    @Query(
+            value = "SELECT ah FROM AlertHistory ah " +
+                    "JOIN FETCH ah.alert a " +
+                    "JOIN FETCH a.coin c " +
+                    "WHERE ah.user.userId = :userId",
+            countQuery = "SELECT COUNT(ah) FROM AlertHistory ah WHERE ah.user.userId = :userId"
+    )
+    Page<AlertHistory> findByUserId(@Param("userId") Long userId, Pageable pageable);
 
     // 특정 사용자(userId)에게 특정 알람(alertId)이 최근 특정 시간 내에 전송되었는지 확인
     @Query("SELECT CASE WHEN COUNT(ah) > 0 THEN TRUE ELSE FALSE END " +

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertHistoryService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertHistoryService.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AlertHistoryService {
 
-    private final AlertHistoryRepositoryImpl alertHistoryRepository;
+    private final AlertHistoryRepositoryImpl alertHistoryRepositoryImpl;
 
     // 알람 리스트 조회
     @Transactional(readOnly = true)
@@ -39,7 +39,7 @@ public class AlertHistoryService {
         int offset = paginationRequest.getOffset();
         int limit = paginationRequest.getLimit();
         Pageable pageable = PageRequest.of(offset, limit);
-        Page<AlertHistory> historyPage = alertHistoryRepository.findAlertHistoryByFilter(userId, pageable);
+        Page<AlertHistory> historyPage = alertHistoryRepositoryImpl.findAlertHistoryByFilter(userId, pageable);
 
         List<AlertHistoryListResponse.AlertHistoryContent> contents = historyPage.getContent().stream()
                 .map(AlertHistoryListResponse.AlertHistoryContent::new)
@@ -56,7 +56,7 @@ public class AlertHistoryService {
 
     // 알람 정보 조회
     public AlertHistoryResponse getAlertHistory(Long alertHistoryId) {
-        AlertHistory alertHistory = alertHistoryRepository.findById(alertHistoryId)
+        AlertHistory alertHistory = alertHistoryRepositoryImpl.findById(alertHistoryId)
                 .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_ALERT_HISTORY));
 
         return new AlertHistoryResponse(alertHistory);
@@ -78,6 +78,6 @@ public class AlertHistoryService {
         alertHistory.setAlert(alert);
         alertHistory.setRegisteredDate(LocalDateTime.now());
 
-        alertHistoryRepository.save(alertHistory);
+        alertHistoryRepositoryImpl.save(alertHistory);
     }
 }


### PR DESCRIPTION
### Description
<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
알람 히스토리 조회 시 전체 데이터를 불러온 후 메모리에서 페이징하던 방식을 개선

### Related Issues
<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

### Changes Made
<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->
- AlertHistoryRepository에 Pageable을 적용한 메서드로 수정
- @Query에 countQuery를 명시하여 페이징 시 count 오류 방지
- 서비스 단에서 subList() 방식 제거, Page<AlertHistory> 반환하도록 수정

### Screenshots or Video
<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing
<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->
- 알럿 히스토리 조회되는지 확인

### Checklist
<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

