### PR TITLE
Upstream/feature/alert/edit4

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepository.java
@@ -1,0 +1,17 @@
+package _1danhebojo.coalarm.coalarm_service.domain.alert.repository;
+
+import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.AlertHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface AlertHistoryRepository {
+    Page<AlertHistory> findAlertHistoryByFilter(Long userId, Pageable pageable);
+    void save(AlertHistory alertHistory);
+    Optional<AlertHistory> findById(Long alertHistoryId);
+    boolean findRecentHistory(Long userId, Long alertId, LocalDateTime minutesAgo);
+    List<Long> findRecentAlertIdsByUser(Long userId, LocalDateTime since);
+}

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepositoryImpl.java
@@ -1,7 +1,9 @@
 package _1danhebojo.coalarm.coalarm_service.domain.alert.repository;
 
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.AlertHistory;
+import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.QAlertHistory;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.jpa.AlertHistoryJpaRepository;
+import com.querydsl.jpa.impl.JPAQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +19,7 @@ import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
-public class AlertHistoryRepositoryImpl {
+public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
 
     private final AlertHistoryJpaRepository alertHistoryJpaRepository;
 
@@ -40,5 +42,18 @@ public class AlertHistoryRepositoryImpl {
 
     public boolean findRecentHistory(Long userId, Long alertId, LocalDateTime minutesAgo) {
         return alertHistoryJpaRepository.findRecentHistory(userId, alertId, minutesAgo);
+    }
+
+    public List<Long> findRecentAlertIdsByUser(Long userId, LocalDateTime since) {
+        QAlertHistory alertHistory = QAlertHistory.alertHistory;
+
+        return new JPAQuery<Long>(entityManager)
+                .select(alertHistory.alert.alertId)
+                .from(alertHistory)
+                .where(
+                        alertHistory.user.userId.eq(userId),
+                        alertHistory.registeredDate.goe(since)
+                )
+                .fetch();
     }
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertRepository.java
@@ -8,6 +8,7 @@ import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.Coin;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.TargetPriceAlert;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.VolumeSpikeAlert;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.GoldenCrossAlert;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -31,4 +32,5 @@ public interface AlertRepository {
     Page<Alert> findAllUserAlerts(Long userId, String symbol, Boolean active, String sort, int offset, int limit);
     Optional<Coin> findCoinBySymbol(String symbol);
     boolean findAlertsByUserIdAndSymbolAndAlertType(Long userId, String symbol, String alertType);
+    List<TickerEntity> findLatestTickersBySymbolList(List<String> symbolList);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertRepositoryImpl.java
@@ -9,8 +9,12 @@ import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.jpa.GoldenCro
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.jpa.TargetPriceJpaRepository;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.jpa.VolumeSpikeJpaRepository;
 
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.QTickerEntity;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerEntity;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -154,6 +158,23 @@ public class AlertRepositoryImpl implements AlertRepository {
 
     public boolean findAlertsByUserIdAndSymbolAndAlertType(Long userId, String symbol, String alertType) {
         return alertJpaRepository.findAlertsByUserIdAndSymbolAndAlertType(userId, symbol, alertType);
+    }
+
+    public List<TickerEntity> findLatestTickersBySymbolList(List<String> symbolList) {
+        QTickerEntity ticker = QTickerEntity.tickerEntity;
+        QTickerEntity tickerSub = new QTickerEntity("tickerSub");
+
+        return query.selectFrom(ticker)
+                .where(
+                        ticker.id.quoteSymbol.in(symbolList),
+                        ticker.id.timestamp.eq(
+                                JPAExpressions
+                                        .select(tickerSub.id.timestamp.max())
+                                        .from(tickerSub)
+                                        .where(tickerSub.id.quoteSymbol.eq(ticker.id.quoteSymbol))
+                        )
+                )
+                .fetch();
     }
 }
 

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/entity/GoldenCrossAlert.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/entity/GoldenCrossAlert.java
@@ -16,10 +16,10 @@ public class GoldenCrossAlert {
     private Long goldenCrossId;
 
     @Column(nullable = true)
-    private Long shortMa;  // 단기 이동평균선
+    private Long shortMa = 7L;  // 단기 이동평균선
 
     @Column(nullable = true)
-    private Long longMa;   // 장기 이동평균선
+    private Long longMa = 20L;   // 장기 이동평균선
 
     @JsonIgnore
     @OneToOne

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertHistoryService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertHistoryService.java
@@ -5,6 +5,7 @@ import _1danhebojo.coalarm.coalarm_service.domain.alert.controller.response.Aler
 import _1danhebojo.coalarm.coalarm_service.domain.alert.controller.response.AlertResponse;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.controller.response.alertHistory.AlertHistoryResponse;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.controller.response.alertHistory.AlertHistoryListResponse;
+import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.AlertHistoryRepository;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.AlertHistoryRepositoryImpl;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.AlertRepositoryImpl;
 import _1danhebojo.coalarm.coalarm_service.domain.alert.repository.entity.Alert;
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AlertHistoryService {
 
-    private final AlertHistoryRepositoryImpl alertHistoryRepositoryImpl;
+    private final AlertHistoryRepository alertHistoryRepository;
 
     // 알람 리스트 조회
     @Transactional(readOnly = true)
@@ -39,7 +40,7 @@ public class AlertHistoryService {
         int offset = paginationRequest.getOffset();
         int limit = paginationRequest.getLimit();
         Pageable pageable = PageRequest.of(offset, limit);
-        Page<AlertHistory> historyPage = alertHistoryRepositoryImpl.findAlertHistoryByFilter(userId, pageable);
+        Page<AlertHistory> historyPage = alertHistoryRepository.findAlertHistoryByFilter(userId, pageable);
 
         List<AlertHistoryListResponse.AlertHistoryContent> contents = historyPage.getContent().stream()
                 .map(AlertHistoryListResponse.AlertHistoryContent::new)
@@ -56,7 +57,7 @@ public class AlertHistoryService {
 
     // 알람 정보 조회
     public AlertHistoryResponse getAlertHistory(Long alertHistoryId) {
-        AlertHistory alertHistory = alertHistoryRepositoryImpl.findById(alertHistoryId)
+        AlertHistory alertHistory = alertHistoryRepository.findById(alertHistoryId)
                 .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_ALERT_HISTORY));
 
         return new AlertHistoryResponse(alertHistory);
@@ -78,6 +79,6 @@ public class AlertHistoryService {
         alertHistory.setAlert(alert);
         alertHistory.setRegisteredDate(LocalDateTime.now());
 
-        alertHistoryRepositoryImpl.save(alertHistory);
+        alertHistoryRepository.save(alertHistory);
     }
 }


### PR DESCRIPTION
### Description
<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
- 알람 체크 로직에서 사용자별 알람 이력을 매번 개별 조회하던 방식을 개선
- 전체 사용자의 알람 이력을 한 번에 일괄 조회하도록 리팩토링
### Related Issues
<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

### Changes Made
<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->
- checkAlertsForSubscribedUsers 메서드에서 사용자별 알람 이력을 일괄 조회하도록 변경
- 기존 알람 이력 개별 조회 로직 제거
- 일괄 조회된 이력 데이터를 사용자 기준으로 필터링하여 알람 조건 확인 로직 적용

### Screenshots or Video
<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing
<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->
- 다수의 사용자 및 알람 조건이 등록된 상황에서 성능 측정

### Checklist
<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

