### PR TITLE
Upstream/feature/alert/edit4

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepository.java
@@ -13,5 +13,6 @@ public interface AlertHistoryRepository {
     void save(AlertHistory alertHistory);
     Optional<AlertHistory> findById(Long alertHistoryId);
     boolean findRecentHistory(Long userId, Long alertId, LocalDateTime minutesAgo);
+    List<Long> findRecentHistories(LocalDateTime minutesAgo);
     List<Long> findRecentAlertIdsByUser(Long userId, LocalDateTime since);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/repository/AlertHistoryRepositoryImpl.java
@@ -26,7 +26,6 @@ public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Transactional
     public Page<AlertHistory> findAlertHistoryByFilter(Long userId, Pageable pageable) {
         return alertHistoryJpaRepository.findByUserId(userId, pageable);
     }
@@ -42,6 +41,19 @@ public class AlertHistoryRepositoryImpl implements AlertHistoryRepository {
 
     public boolean findRecentHistory(Long userId, Long alertId, LocalDateTime minutesAgo) {
         return alertHistoryJpaRepository.findRecentHistory(userId, alertId, minutesAgo);
+    }
+
+    @Override
+    public List<Long> findRecentHistories(LocalDateTime minutesAgo) {
+        QAlertHistory alertHistory = QAlertHistory.alertHistory;
+
+        return new JPAQuery<Long>(entityManager)
+                .select(alertHistory.alert.alertId)
+                .from(alertHistory)
+                .where(
+                        alertHistory.registeredDate.goe(minutesAgo)
+                )
+                .fetch();
     }
 
     public List<Long> findRecentAlertIdsByUser(Long userId, LocalDateTime since) {

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertSSEService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertSSEService.java
@@ -281,7 +281,7 @@ public class AlertSSEService {
         }
 
         // 더 이상 연결이 없는 유저에 대해서는 Map에서 아예 지워버리고, 연결이 남아 있는 경우만 최신 상태로 다시 저장한다."
-        if (emitters.isEmpty()) {
+        if (emitters != null && !emitters.isEmpty()) {
             userEmitters.remove(userId);
         }
 


### PR DESCRIPTION
### Description
<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
사용자별로 반복 조회하던 알림 히스토리 및 코인 티커 조회 로직을 전체 조회 방식
SSE 알림 전송 시 발생하던 NullPointerException 문제 예외 처리

### Related Issues
<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

### Changes Made
<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->
- 사용자별 알림 히스토리 조회 → 전체 조회
- 티커 정보도 전체 심볼 기준으로 한 번만 조회하도록 개선
- SSE 알림 전송 시 emitters가 null인 경우 예외 발생하지 않도록 방어 로직 추가

### Screenshots or Video
<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing
<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

### Checklist
<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

