### PR TITLE
fix: 디스코드 웹훅 url 유효성 검사 로직 개선

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/user/service/UserServiceImpl.java
@@ -227,5 +227,37 @@ public class UserServiceImpl implements UserService {
         if (!matcher.matches()) {
             throw new ApiException(AppHttpStatus.INVALID_DISCORD_WEBHOOK);
         }
+
+        // 실제 유효한 URL인지 테스트 메시지 보내기
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            String payload = """
+        {
+            "content": "코알람에 오신 걸 환영합니다! 🎉\\n이제 디스코드에서 실시간 알림을 받아보실 수 있어요.",
+            "username": "코알람"
+        }
+        """;
+
+            HttpEntity<String> request = new HttpEntity<>(payload, headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    webhookUrl,
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                throw new ApiException(AppHttpStatus.INVALID_DISCORD_WEBHOOK);
+            }
+
+        } catch (Exception e) {
+            log.error("디스코드 웹훅 테스트 실패: {}", e.getMessage());
+            throw new ApiException(AppHttpStatus.INVALID_DISCORD_WEBHOOK);
+        }
     }
 }


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->

기존에는 디스코드 웹훅 입력 시 형식만 정규식으로 검증하고 있었으나,
실제로 유효한 웹훅인지 확인할 수 없어 문제가 있었음

이번 PR에서는 입력된 웹훅 URL이 실제로 디스코드 채널과 연결되어 있는지 확인하기 위해
"코알람에 오신 걸 환영합니다 🎉" 라는 테스트 메시지를 전송하도록 기능을 추가


### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Close #164

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. UserServiceImpl 내 validateDiscordWebhookUrl()에 RestTemplate 기반 POST 요청 로직 추가
2. 유효성 확인 메시지 "코알람에 오신 걸 환영합니다 🎉" 디스코드 채널로 전송


### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. 올바른 웹훅 입력 시 디스코드 채널에 환영 메시지 도착 여부 확인
2. 잘못된 URL 입력 시 400 에러 응답 및 예외 처리 확인



### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

