### PR TITLE
Upstream/alert/edit/6

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertHistoryService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertHistoryService.java
@@ -48,6 +48,7 @@ public class AlertHistoryService {
     }
 
     // 알람 정보 조회
+    @Transactional(readOnly = true)
     public AlertHistoryResponse getAlertHistory(Long alertHistoryId) {
         AlertHistoryEntity alertHistory = alertHistoryRepository.findById(alertHistoryId)
                 .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_ALERT_HISTORY));

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertSSEService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertSSEService.java
@@ -94,13 +94,16 @@ public class AlertSSEService {
             List<SseEmitter> failedEmitters = new ArrayList<>();
             Long userId = entry.getKey();
             List<SseEmitter> emitters = entry.getValue();
-            for (SseEmitter emitter : emitters) {
-                try {
-                    emitter.send(SseEmitter.event()
-                            .name("heartbeat")
-                            .data("keep-alive")); // 클라이언트에선 로그로만 찍어도 OK
-                } catch (IOException e) {
-                    failedEmitters.add(emitter);
+
+            if (emitters != null && !Objects.requireNonNull(emitters).isEmpty()) {
+                for (SseEmitter emitter : emitters) {
+                    try {
+                        emitter.send(SseEmitter.event()
+                                .name("heartbeat")
+                                .data("keep-alive")); // 클라이언트에선 로그로만 찍어도 OK
+                    } catch (IOException e) {
+                        failedEmitters.add(emitter);
+                    }
                 }
             }
 
@@ -218,7 +221,7 @@ public class AlertSSEService {
         if(userId == null) { return null;}
         // 이미 존재하는 emitter가 있으면 재사용
         List<SseEmitter> existingEmitters = userEmitters.get(userId);
-        if (existingEmitters != null) {
+        if (existingEmitters != null && !Objects.requireNonNull(existingEmitters).isEmpty()) {
             // 살아있는 emitter만 필터링
             List<SseEmitter> failedEmitters = new ArrayList<>();
 
@@ -272,7 +275,7 @@ public class AlertSSEService {
     public void sendAlertToUserSSE(Long userId, AlertEntity alert) {
         List<SseEmitter> emitters = userEmitters.get(userId);
 
-        if (emitters == null || emitters.isEmpty()) {
+        if (emitters != null && !Objects.requireNonNull(emitters).isEmpty()) {
             AlertSSEResponse response = new AlertSSEResponse(alert);
             List<SseEmitter> failedEmitters = new ArrayList<>();
 
@@ -349,7 +352,7 @@ public class AlertSSEService {
     public void removeEmitter(Long userId) {
         List<SseEmitter> emitters = userEmitters.remove(userId); // 해당 userId의 모든 SSE 제거
 
-        if (emitters != null) {
+        if (emitters != null && !Objects.requireNonNull(emitters).isEmpty()) {
             for (SseEmitter emitter : emitters) {
                 try {
                     emitter.complete(); // 안전하게 종료
@@ -364,7 +367,7 @@ public class AlertSSEService {
     // userEmitters에서 사용자 제거
     public void removeSingleEmitter(Long userId, SseEmitter emitter) {
         List<SseEmitter> emitters = userEmitters.get(userId);
-        if (emitters != null) {
+        if (emitters != null && !Objects.requireNonNull(emitters).isEmpty()) {
             emitters.remove(emitter);
             try {
                 emitter.complete();

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertSSEService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/AlertSSEService.java
@@ -116,6 +116,7 @@ public class AlertSSEService {
     // 특정 시간마다 디스코드 알림 전송
     @Scheduled(fixedRateString = "#{@alarmProperties.sendDiscordInterval}")
     public void discordScheduler() {
+        log.info("디스코드 알림 전송 시작");
         // 조건에 맞는 알람만 필터링 (지정가 or 골든크로스)
         Map<Long, List<AlertEntity>> filteredAlerts = activeAlertList.entrySet()
                 .stream()
@@ -153,6 +154,7 @@ public class AlertSSEService {
                 sendAlertListToUserDiscord(userId, triggeredAlerts);
             }
         });
+        log.info("디스코드 알림 종료");
     }
 
     // 특정 시간마다 긁어와서 queue에 추가
@@ -177,6 +179,8 @@ public class AlertSSEService {
         LocalDateTime minutesAgo = LocalDateTime.now().minusSeconds(30);
         List<Long> recentAlertIds = alertHistoryRepository.findRecentHistories(minutesAgo);
         Set<Long> recentAlertIdSet = new HashSet<>(recentAlertIds);
+
+        // SSE 알람 전송
         for (Long userId : userEmitters.keySet()) {
             List<AlertEntity> activeAlerts = new ArrayList<>(activeAlertList.getOrDefault(userId, Collections.emptyList()));
 

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/DiscordService.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/alert/service/DiscordService.java
@@ -39,17 +39,27 @@ public class DiscordService {
             return;
         }
 
-        Map<String, Object> body = Map.of(
-                "username", "코알람",
-                "embeds", embeds
-        );
+        int batchSize = 10;
+        for (int i = 0; i < embeds.size(); i += batchSize) {
+            List<Map<String, Object>> batch = embeds.subList(i, Math.min(i + batchSize, embeds.size()));
 
-        ResponseEntity<String> response = restTemplate.postForEntity(webhookUrl, body, String.class);
+            Map<String, Object> body = Map.of(
+                    "username", "코알람",
+                    "embeds", batch
+            );
 
-        if (!response.getStatusCode().is2xxSuccessful()) {
-            throw new ApiException(AppHttpStatus.FAILED_TO_SEND_DISCORD);
+            try {
+                ResponseEntity<String> response = restTemplate.postForEntity(webhookUrl, body, String.class);
+                if (!response.getStatusCode().is2xxSuccessful()) {
+                    throw new ApiException(AppHttpStatus.FAILED_TO_SEND_DISCORD);
+                }
+            } catch (Exception e) {
+                System.err.println("❌ Discord 전송 실패 - " + e.getMessage());
+                // 필요하다면 로깅이나 슬랙 전송 등 추가 처리
+            }
         }
     }
+
 
     public Map<String, Object> buildEmbedMapFromAlert(AlertEntity alert) {
         String title;


### PR DESCRIPTION
### Description
<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
Discord 알림 전송 로직 개선 및 병합 과정에서 누락된 코드 복구와 예외 처리를 추가
트랜잭션 범위 밖에서 Lazy 데이터를 조회하는 문제를 해결
Discord embeds 관련 에러를 방지하기 위한 로직을 도입

### Related Issues
<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made
<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->
- Discord 알림 전송 시 전송 조건 추가
- Discord embeds 10개씩 분할 전송하도록 개선
- 사용하지 않는 에러 로그 제거
- 병합 과정에서 누락된 코드 복구
- open_in_view 설정에 따른 LazyInitializationException 문제 해결을 위해 트랜잭션 범위 추가


### Screenshots or Video
<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing
<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->
1. Discord 알림 전송 테스트: 조건 만족 시 embeds가 10개씩 정상 전송되는지 확인
2. Lazy 데이터 접근 시 예외 발생 여부 확인

### Checklist
<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes
<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

