### PR TITLE
refactor: 불필요한 쿼리 삭제

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepository.java
@@ -6,6 +6,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TickerRepository {
-    List<TickerEntity> findByCoinIdOrderedByUtcDateTime(Long coinId);
+    List<TickerEntity> findByCoinIdOrderedByUtcDateTime(String symbol);
     Optional<TickerEntity> findLatestBySymbol(String symbol);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepositoryImpl.java
@@ -19,26 +19,13 @@ public class TickerRepositoryImpl implements TickerRepository{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<TickerEntity> findByCoinIdOrderedByUtcDateTime(Long coinId) {
+    public List<TickerEntity> findByCoinIdOrderedByUtcDateTime(String symbol) {
         QTickerEntity ticker = QTickerEntity.tickerEntity;
-        QCoinEntity coin = QCoinEntity.coinEntity;
-
-        // 코인 정보 먼저 조회
-        CoinEntity coinEntity = queryFactory
-                .selectFrom(coin)
-                .where(coin.id.eq(coinId))
-                .fetchOne();
-
-        if (coinEntity == null) {
-            return Collections.emptyList();
-        }
-
-        String coinSymbol = coinEntity.getSymbol();
 
         // 명확한 형태로 검색
         return queryFactory
                 .selectFrom(ticker)
-                .where(ticker.id.baseSymbol.eq(coinSymbol))
+                .where(ticker.id.baseSymbol.eq(symbol))
                 .orderBy(ticker.id.timestamp.asc())
                 .limit(100)
                 .fetch();

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinIndicatorServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/CoinIndicatorServiceImpl.java
@@ -93,8 +93,8 @@ public class CoinIndicatorServiceImpl implements CoinIndicatorService {
         return new CoinIndicatorResponse(macdDTO, rsiDTO, longShortStrengthDTO, coinDTO);
     }
 
-    private List<BigDecimal> getClosingPrices(Long coinId) {
-        List<TickerEntity> tickers = tickerRepository.findByCoinIdOrderedByUtcDateTime(coinId);
+    private List<BigDecimal> getClosingPrices(String symbol) {
+        List<TickerEntity> tickers = tickerRepository.findByCoinIdOrderedByUtcDateTime(symbol);
         return tickers.stream()
                 .map(TickerEntity::getClose)
                 .collect(Collectors.toList());
@@ -274,7 +274,7 @@ public class CoinIndicatorServiceImpl implements CoinIndicatorService {
                 .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND));
 
         // 2. 가격 데이터 조회
-        List<BigDecimal> prices = getClosingPrices(coinEntity.getId());
+        List<BigDecimal> prices = getClosingPrices(symbol);
 
         if (prices.size() < 26) {
             throw new ApiException(AppHttpStatus.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
- 기존에 coinId를 인자값으로 받음으로써 coinId -> coinEntity -> symbol를 얻은 후 쿼리를 날리는 방식이 비효율적임
- 처음부터 symbol을 인자값으로 받고 select 쿼리문을 삭제

