### PR TITLE
feat: RSI 계산을 위한 CandleRepository 구현 및 서비스 적용

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/CandleRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/CandleRepository.java
@@ -1,4 +1,9 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository;
 
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.CandleEntity;
+
+import java.util.List;
+
 public interface CandleRepository {
+    List<CandleEntity> findRecentCandles(String symbol, int limit);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/CandleRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/CandleRepositoryImpl.java
@@ -1,9 +1,33 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository;
 
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.CandleEntity;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.QCandleEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class CandleRepositoryImpl implements CandleRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CandleEntity> findRecentCandles(String symbol, int limit) {
+        QCandleEntity candle = QCandleEntity.candleEntity;
+
+        return queryFactory
+                .selectFrom(candle)
+                .where(
+                        candle.id.exchange.eq("upbit"),
+                        candle.id.baseSymbol.eq(symbol),
+                        candle.id.quoteSymbol.eq("KRW"),
+                        candle.id.timeframe.eq("1m")
+                )
+                .orderBy(candle.id.timestamp.desc())
+                .limit(limit)
+                .fetch();
+    }
 }


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
RSI 계산에 사용하는 가격 데이터를 기존 Ticker 기반에서 Candle 기반으로 변경하여, 보다 정확하고 일관된 계산이 가능하도록 개선하였습니다.
이를 위해 CandleRepository 및 구현체를 새로 정의하고, 서비스 로직 내 getClosingPrices()를 수정하였습니다.

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #[이슈 번호]

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. findRecentCandles(String symbol, int limit) 메서드 구현 (QueryDSL)
2. CoinIndicatorServiceImpl 내 getClosingPrices() 로직을 Candle 기반으로 수정
3. RSI 계산 시 사용되는 가격 데이터를 최신 200개 캔들 기준으로 조회하도록 변경

### Screenshots or Video

<!--
  변경된 사항이 UI에 영향을 미치는 경우, 변경 전후의 스크린샷이나 동영상을 첨부하세요.
-->

### Testing

<!--
  변경 사항을 테스트한 방법을 설명하세요.
  테스트한 환경 (OS, 브라우저, 장치 등)과 테스트 절차를 구체적으로 기술합니다.
-->

1. [테스트 1]
2. [테스트 2]
4. [테스트 3]

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

