### PR TITLE
refactor: 김치 프리미엄계산 비동기 처리

### DIFF
--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/repository/CoinRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/repository/CoinRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface CoinRepository {
     List<CoinEntity> findAlertCoinsByUserId(Long userId);
     List<CoinWithPriceDTO> searchCoinsWithLatestPrice(String keyword, String quoteSymbol);
+    List<CoinEntity> findAllWithoutUSDT();
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/repository/CoinRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/coin/repository/CoinRepositoryImpl.java
@@ -67,6 +67,14 @@ public class CoinRepositoryImpl implements CoinRepository {
                 .fetch();
     }
 
+    @Override
+    public List<CoinEntity> findAllWithoutUSDT() {
+        return query.selectFrom(coinEntity)
+                .where(coinEntity.symbol.ne("USDT"))
+                .orderBy(coinEntity.id.asc())
+                .fetch();
+    }
+
     private BooleanExpression keywordContains(String keyword) {
         if (!StringUtils.hasText(keyword)) return null;
         return coinEntity.name.containsIgnoreCase(keyword)

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/KimchiPremiumRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/KimchiPremiumRepository.java
@@ -3,15 +3,17 @@ package _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository;
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.entity.CoinEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.KimchiPremiumEntity;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface KimchiPremiumRepository {
     List<KimchiPremiumEntity> findAllKimchiPremiums(int offset, int limit);
 
-    Optional<KimchiPremiumEntity> findTopByCoinAndRegDtBetweenOrderByRegDtDesc(
-            CoinEntity coin,
+    public Map<String, BigDecimal> findLatestPremiumBySymbolsAndRegDtBetween(
+            List<String> symbols,
             LocalDateTime fromDateTime,
             LocalDateTime toDateTime
     );

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/KimchiPremiumRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/KimchiPremiumRepositoryImpl.java
@@ -3,16 +3,20 @@ package _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository;
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.entity.CoinEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.KimchiPremiumEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.QKimchiPremiumEntity;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -43,28 +47,44 @@ public class KimchiPremiumRepositoryImpl implements KimchiPremiumRepository{
     }
 
     @Override
-    public Optional<KimchiPremiumEntity> findTopByCoinAndRegDtBetweenOrderByRegDtDesc(
-            CoinEntity coin,
+    public Map<String, BigDecimal> findLatestPremiumBySymbolsAndRegDtBetween(
+            List<String> symbols,
             LocalDateTime fromDateTime,
             LocalDateTime toDateTime
     ) {
         QKimchiPremiumEntity kp = QKimchiPremiumEntity.kimchiPremiumEntity;
+        QKimchiPremiumEntity kpSub = new QKimchiPremiumEntity("kpSub");
 
         Instant fromInstant = fromDateTime.atZone(ZoneId.systemDefault()).toInstant();
         Instant toInstant = toDateTime.atZone(ZoneId.systemDefault()).toInstant();
 
-        KimchiPremiumEntity result = queryFactory
-                .selectFrom(kp)
+        List<Tuple> results = queryFactory
+                .select(kp.coin.symbol, kp.kimchiPremium)
+                .from(kp)
                 .where(
-                        kp.coin.eq(coin),
-                        kp.regDt.after(fromInstant).or(kp.regDt.eq(fromInstant)),
-                        kp.regDt.before(toInstant).or(kp.regDt.eq(toInstant))
+                        kp.coin.symbol.in(symbols),
+                        kp.regDt.goe(fromInstant),
+                        kp.regDt.lt(toInstant),
+                        kp.regDt.eq(
+                                JPAExpressions
+                                        .select(kpSub.regDt.max())
+                                        .from(kpSub)
+                                        .where(
+                                                kpSub.coin.symbol.eq(kp.coin.symbol),
+                                                kpSub.regDt.goe(fromInstant),
+                                                kpSub.regDt.lt(toInstant)
+                                        )
+                        )
                 )
-                .orderBy(kp.regDt.desc())
-                .fetchFirst();
+                .fetch();
 
-        return Optional.ofNullable(result);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(kp.coin.symbol),
+                        tuple -> tuple.get(kp.kimchiPremium)
+                ));
     }
+
 
     @Override
     public long countAllKimchiPremiums() {

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepository.java
@@ -3,9 +3,11 @@ package _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerEntity;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface TickerRepository {
     List<TickerEntity> findByCoinIdOrderedByUtcDateTime(String symbol);
     Optional<TickerEntity> findLatestBySymbol(String symbol);
+    List<TickerEntity> findLatestTickers(List<String> coinSymbols, String quoteSymbol);
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepositoryImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/TickerRepositoryImpl.java
@@ -4,26 +4,28 @@ import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.entity.CoinEnt
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.entity.QCoinEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.QTickerEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerEntity;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class TickerRepositoryImpl implements TickerRepository{
 
-    private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory query;
 
     @Override
     public List<TickerEntity> findByCoinIdOrderedByUtcDateTime(String symbol) {
         QTickerEntity ticker = QTickerEntity.tickerEntity;
 
         // 명확한 형태로 검색
-        return queryFactory
+        return query
                 .selectFrom(ticker)
                 .where(ticker.id.baseSymbol.eq(symbol))
                 .orderBy(ticker.id.timestamp.asc())
@@ -36,11 +38,35 @@ public class TickerRepositoryImpl implements TickerRepository{
         QTickerEntity ticker = QTickerEntity.tickerEntity;
 
         return Optional.ofNullable(
-                queryFactory
+                query
                         .selectFrom(ticker)
                         .where(ticker.id.baseSymbol.eq(symbol))
                         .orderBy(ticker.id.timestamp.desc()) // 최신 순으로 정렬
                         .fetchFirst()
         );
     }
+
+    @Override
+    public List<TickerEntity> findLatestTickers(List<String> coinSymbols, String quoteSymbol){
+        QTickerEntity ticker = QTickerEntity.tickerEntity;
+        QTickerEntity subTicker = new QTickerEntity("subTicker");
+
+        return query
+                .selectFrom(ticker)
+                .where(
+                        ticker.id.baseSymbol.in(coinSymbols),
+                        ticker.id.quoteSymbol.eq(quoteSymbol),
+                        ticker.id.timestamp.eq(
+                                JPAExpressions
+                                        .select(subTicker.id.timestamp.max())
+                                        .from(subTicker)
+                                        .where(
+                                                subTicker.id.baseSymbol.eq(ticker.id.baseSymbol),
+                                                subTicker.id.quoteSymbol.eq(quoteSymbol)
+                                        )
+                        )
+                )
+                .fetch();
+    }
+
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/jpa/KimchiPremiumJpaRepository.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/repository/jpa/KimchiPremiumJpaRepository.java
@@ -3,5 +3,5 @@ package _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.jpa;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.KimchiPremiumEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface KimchiPreminumJpaRepository extends JpaRepository<KimchiPremiumEntity,Long> {
+public interface KimchiPremiumJpaRepository extends JpaRepository<KimchiPremiumEntity,Long> {
 }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/KimchiPremiumServiceImpl.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/domain/dashboard/service/KimchiPremiumServiceImpl.java
@@ -1,19 +1,20 @@
 package _1danhebojo.coalarm.coalarm_service.domain.dashboard.service;
 
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.CoinRepository;
+import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.jpa.CoinJpaRepository;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.controller.response.ResponseKimchiPremium;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.KimchiPremiumRepository;
 import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.entity.CoinEntity;
-import _1danhebojo.coalarm.coalarm_service.domain.coin.repository.jpa.CoinJpaRepository;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.TickerRepository;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.KimchiPremiumEntity;
 import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.entity.TickerEntity;
-import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.jpa.KimchiPreminumJpaRepository;
-import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.jpa.TickerJpaRepository;
+import _1danhebojo.coalarm.coalarm_service.domain.dashboard.repository.jpa.KimchiPremiumJpaRepository;
 import _1danhebojo.coalarm.coalarm_service.global.api.ApiException;
 import _1danhebojo.coalarm.coalarm_service.global.api.AppHttpStatus;
 import _1danhebojo.coalarm.coalarm_service.global.api.OffsetResponse;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,37 +24,34 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class KimchiPremiumServiceImpl implements KimchiPremiumService{
     private final KimchiPremiumRepository kimchiPremiumRepository;
-    private final KimchiPreminumJpaRepository kimchiPreminumJpaRepository;
-    private final TickerJpaRepository tickerJpaRepository;
+    private final TickerRepository tickerRepository;
+    private final CoinRepository coinRepository;
+    private final KimchiPremiumJpaRepository kimchiPremiumJpaRepository;
     private final CoinJpaRepository coinJpaRepository;
+
+    @Resource(name = "kimchiTaskExecutor")
+    private final Executor kimchiTaskExecutor;
     private static final String EXCHANGE_RATE_API_URL = "https://api.exchangerate-api.com/v4/latest/USD";
-    private static final List<String> SUPPORTED_COINS = new ArrayList<>();
     // 계산 시 사용할 스케일 상수 정의
     private static final int CALCULATION_SCALE = 16;
     private static final int DISPLAY_SCALE = 8;
 
     @Override
     public OffsetResponse<ResponseKimchiPremium> getKimchiPremiums(int offset, int limit) {
-        long startTime = System.currentTimeMillis();
-
         List<ResponseKimchiPremium> premiums = kimchiPremiumRepository.findAllKimchiPremiums(offset, limit)
                 .stream()
                 .map(ResponseKimchiPremium::fromEntity)
                 .toList();
-
-        long endTime = System.currentTimeMillis();
-        long executionTime = endTime - startTime;
-        log.info("실행 시간: " + executionTime + "ms");
 
         long totalElements = kimchiPremiumRepository.countAllKimchiPremiums();
 
@@ -65,144 +63,156 @@ public class KimchiPremiumServiceImpl implements KimchiPremiumService{
         );
     }
 
-    private void initializeSupportedCoins() {
-        try {
-            List<CoinEntity> coins = coinJpaRepository.findAllBy();
-
-            // 기존 목록 초기화 (재실행 시 중복 방지)
-            SUPPORTED_COINS.clear();
-
-            // 조회된 코인의 심볼을 리스트에 추가
-            for (CoinEntity coin : coins) {
-                if(coin.getSymbol().equals("USDT")) continue;
-                SUPPORTED_COINS.add(coin.getSymbol());
-            }
-
-            log.info("지원 코인 {}개 로드 완료: {}", SUPPORTED_COINS.size(), SUPPORTED_COINS);
-        } catch (Exception e) {
-            log.error("지원 코인 목록 초기화 중 오류 발생: {}", e.getMessage(), e);
-        }
-    }
-
     @Override
     public void calculateAndSaveKimchiPremium() {
-        initializeSupportedCoins();
+        List<CoinEntity> coins = Optional.ofNullable(coinRepository.findAllWithoutUSDT())
+                .filter(list -> !list.isEmpty())
+                .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND_COIN));
+
+        List<String> coinSymbols = coins.stream()
+                .map(CoinEntity::getSymbol)
+                .toList();
 
         // USD/KRW 환율 한 번만 가져오기
         BigDecimal exchangeRate = getUsdToKrwExchangeRate();
         if (exchangeRate.compareTo(BigDecimal.ZERO) == 0) {
             log.warn("환율 데이터를 가져올 수 없습니다.");
+            throw new ApiException(AppHttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        Map<String, Optional<TickerEntity>> krwTickers = getLatestTickers(coinSymbols, "KRW");
+        Map<String, Optional<TickerEntity>> usdtTickers = getLatestTickers(coinSymbols, "USDT");
+
+        if (krwTickers.isEmpty() || usdtTickers.isEmpty()) {
+            log.warn("코인의 가격 데이터를 찾을 수 없습니다.");
             throw new ApiException(AppHttpStatus.NOT_FOUND);
         }
-
-        log.info("오늘의 USD/KRW 환율: {}", exchangeRate);
-
-        // 모든 지원 코인에 대해 김치프리미엄 계산
-        for (String coinSymbol : SUPPORTED_COINS) {
-            try {
-                calculateAndSaveKimchiPremiumForCoin(coinSymbol, exchangeRate);
-            } catch (Exception e) {
-                log.error("{} 코인의 김치 프리미엄 계산 중 오류 발생: {}", coinSymbol, e.getMessage());
-                // 한 코인에서 오류가 발생해도 다른 코인은 계속 진행
-            }
-        }
-    }
-
-    private void calculateAndSaveKimchiPremiumForCoin(String coinSymbol, BigDecimal exchangeRate) {
-        String krwQuoteSymbol = "KRW";
-        String usdtQuoteSymbol ="USDT";
-
-        Optional<TickerEntity> krwTicker = tickerJpaRepository.findFirstByIdBaseSymbolAndIdQuoteSymbolOrderByIdTimestampDesc(
-                coinSymbol, krwQuoteSymbol);
-        Optional<TickerEntity> usdtTicker = tickerJpaRepository.findFirstByIdBaseSymbolAndIdQuoteSymbolOrderByIdTimestampDesc(
-                coinSymbol, usdtQuoteSymbol);
-
-        if (krwTicker.isEmpty() || usdtTicker.isEmpty()) {
-            log.warn("{}의 가격 데이터를 찾을 수 없습니다.", coinSymbol);
-            throw new ApiException(AppHttpStatus.NOT_FOUND);
-        }
-
-        BigDecimal krwPrice = krwTicker.get().getClose();
-        BigDecimal usdtPrice = usdtTicker.get().getClose();
-
-        log.info("{} KRW 가격: {}", coinSymbol, krwPrice);
-        log.info("{} USDT 가격: {}", coinSymbol, usdtPrice);
-
-        // 김치 프리미엄 계산 (정확도를 위해 높은 스케일 사용)
-        BigDecimal globalPriceInKrw = usdtPrice.multiply(exchangeRate).setScale(CALCULATION_SCALE, RoundingMode.HALF_UP);
-        log.info("{} 글로벌 가격(KRW 환산): {}", coinSymbol, globalPriceInKrw);
-
-        // 김치프리미엄 = ((한국가격 - 글로벌가격) / 글로벌가격) * 100
-        BigDecimal priceDifference = krwPrice.subtract(globalPriceInKrw);
-        BigDecimal kimchiPremium;
-
-        if (globalPriceInKrw.compareTo(BigDecimal.ZERO) == 0) {
-            // 분모가 0인 경우 방지
-            kimchiPremium = BigDecimal.ZERO;
-            log.warn("글로벌 가격이 0이라 김치프리미엄을 0으로 설정합니다.");
-        } else {
-            kimchiPremium = priceDifference
-                    .divide(globalPriceInKrw, CALCULATION_SCALE, RoundingMode.HALF_UP)
-                    .multiply(BigDecimal.valueOf(100))
-                    .setScale(DISPLAY_SCALE, RoundingMode.HALF_UP);
-        }
-
-        log.info("{} 김치프리미엄 계산 결과: {}%", coinSymbol, kimchiPremium);
-
-        // 코인 엔티티 가져오기
-        Optional<CoinEntity> coinEntity = coinJpaRepository.findBySymbol(coinSymbol);
-        if (coinEntity.isEmpty()) {
-            log.warn("{} 코인 정보를 찾을 수 없습니다.", coinSymbol);
-            throw new ApiException(AppHttpStatus.NOT_FOUND);
-        }
-
-        CoinEntity coin = coinJpaRepository.findBySymbol(coinSymbol)
-                .orElseThrow(() -> new ApiException(AppHttpStatus.NOT_FOUND));
 
         // 어제 자정 시간 계산
         LocalDateTime yesterday = LocalDate.now().minusDays(1).atStartOfDay();
         LocalDateTime today = LocalDate.now().atStartOfDay();
+        Map<String, BigDecimal> yesterdayPremiums = kimchiPremiumRepository
+                .findLatestPremiumBySymbolsAndRegDtBetween(coinSymbols, yesterday, today);
 
-        // 어제의 마지막 김치 프리미엄 조회 (어제 자정 이후부터 오늘 자정 이전까지)
-        Optional<KimchiPremiumEntity> yesterdayPremium = kimchiPremiumRepository
-                .findTopByCoinAndRegDtBetweenOrderByRegDtDesc(coinEntity.get(), yesterday, today);
 
-        // 일별 변동률 계산
-        BigDecimal dailyChange = calculateDailyChange(kimchiPremium, yesterdayPremium);
+        List<CompletableFuture<KimchiPremiumEntity>> futures = new ArrayList<>();
+        for(CoinEntity coin: coins){
+            CompletableFuture<KimchiPremiumEntity> future = CompletableFuture.supplyAsync(()->{
+                return calculateKimchiPremiumForCoin(
+                        coin, exchangeRate, krwTickers, usdtTickers,
+                        yesterdayPremiums);
+            },kimchiTaskExecutor);
 
-        // 김치 프리미엄 엔티티 생성 및 저장
-        KimchiPremiumEntity kimchiPremiumEntity = KimchiPremiumEntity.builder()
-                .coin(coin)
-                .domesticPrice(krwPrice)
-                .globalPrice(usdtPrice)
-                .exchangeRate(exchangeRate)
-                .kimchiPremium(kimchiPremium)
-                .dailyChange(dailyChange)
-                .build();
+            futures.add(future);
+        }
 
-        kimchiPreminumJpaRepository.save(kimchiPremiumEntity);
-        log.info("{} 김치 프리미엄 저장 완료: {}%, 일별 변동률: {}%", coinSymbol, kimchiPremium, dailyChange);
+        List<KimchiPremiumEntity> kimchiPremiums = futures.stream()
+                .map(CompletableFuture::join) // 각 Future의 결과를 기다림
+                .filter(Objects::nonNull) // null 값 제거 (계산 실패한 경우)
+                .collect(Collectors.toList());
+
+        // 계산된 김치프리미엄 일괄 저장
+        if (!kimchiPremiums.isEmpty()) {
+            try {
+                kimchiPremiumJpaRepository.saveAll(kimchiPremiums);
+                log.info("김치프리미엄 {}개 데이터 저장 완료", kimchiPremiums.size());
+            } catch (Exception e) {
+                log.error("김치프리미엄 데이터 저장 중 오류 발생", e);
+                throw new ApiException(AppHttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        } else {
+            log.warn("저장할 김치프리미엄 데이터가 없습니다.");
+        }
     }
 
-    private BigDecimal calculateDailyChange(BigDecimal currentValue, Optional<KimchiPremiumEntity> yesterdayPremium) {
-        if (yesterdayPremium.isEmpty()) {
+    //최신 코인 정보 조회
+    private Map<String, Optional<TickerEntity>> getLatestTickers(List<String> coinSymbols,String quoteSymbol){
+        List<TickerEntity> tickers = tickerRepository.findLatestTickers(coinSymbols, quoteSymbol);
+
+        Map<String, TickerEntity> tickerMap = tickers.stream()
+                .collect(Collectors.toMap(
+                        ticker -> ticker.getId().getBaseSymbol(),
+                        ticker -> ticker,
+                        (existing, replacement) -> existing
+                ));
+
+        return coinSymbols.stream()
+                .collect(Collectors.toMap(
+                        symbol -> symbol,
+                        symbol -> Optional.ofNullable(tickerMap.get(symbol))
+                ));
+    }
+
+    private KimchiPremiumEntity calculateKimchiPremiumForCoin(
+            CoinEntity coinEntity,
+            BigDecimal exchangeRate,
+            Map<String, Optional<TickerEntity>> krwTickers,
+            Map<String, Optional<TickerEntity>> usdtTickers,
+            Map<String, BigDecimal> yesterdayPremiums) {
+        try {
+            String coinSymbol = coinEntity.getSymbol();
+            Optional<TickerEntity> krwTicker = krwTickers.get(coinSymbol);
+            Optional<TickerEntity> usdtTicker = usdtTickers.get(coinSymbol);
+
+            if (krwTicker == null || krwTicker.isEmpty() || usdtTicker == null || usdtTicker.isEmpty()) {
+                log.warn("{}의 필요한 데이터를 찾을 수 없습니다.", coinSymbol);
+                return null;
+            }
+
+            BigDecimal krwPrice = krwTicker.get().getClose();
+            BigDecimal usdtPrice = usdtTicker.get().getClose();
+
+            BigDecimal globalPriceInKrw = usdtPrice.multiply(exchangeRate)
+                    .setScale(CALCULATION_SCALE, RoundingMode.HALF_UP);
+
+            BigDecimal priceDifference = krwPrice.subtract(globalPriceInKrw);
+            BigDecimal kimchiPremium;
+
+            if (globalPriceInKrw.compareTo(BigDecimal.ZERO) == 0) {
+                // 분모가 0인 경우 방지
+                kimchiPremium = BigDecimal.ZERO;
+                log.warn("글로벌 가격이 0이라 김치프리미엄을 0으로 설정합니다.");
+            } else {
+                kimchiPremium = priceDifference
+                        .divide(globalPriceInKrw, CALCULATION_SCALE, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(DISPLAY_SCALE, RoundingMode.HALF_UP);
+            }
+
+            // 일별 변동률 계산
+            BigDecimal dailyChange = calculateDailyChange(kimchiPremium, yesterdayPremiums.get(coinSymbol));
+
+            return KimchiPremiumEntity.builder()
+                    .coin(coinEntity)
+                    .domesticPrice(krwPrice)
+                    .globalPrice(usdtPrice)
+                    .exchangeRate(exchangeRate)
+                    .kimchiPremium(kimchiPremium)
+                    .dailyChange(dailyChange)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("{}의 김치프리미엄 계산 중 오류 발생", coinEntity.getSymbol(), e);
+            return null;
+        }
+    }
+
+    private BigDecimal calculateDailyChange(BigDecimal currentValue, BigDecimal yesterdayPremium) {
+        if (yesterdayPremium == null) {
             return BigDecimal.ZERO; // 어제 데이터가 없으면 변동률 0
         }
 
-        BigDecimal yesterdayValue = yesterdayPremium.get().getKimchiPremium();
-        log.info("어제의 김치프리미엄: {}", yesterdayValue);
-
         // 변동률 계산: (오늘값 - 어제값) / |어제값| * 100
         // 분모가 0인 경우를 방지하기 위한 처리
-        if (yesterdayValue.compareTo(BigDecimal.ZERO) == 0) {
+        if (yesterdayPremium.compareTo(BigDecimal.ZERO) == 0) {
             // 어제 값이 0인 경우 (변동률 계산 불가)
             return currentValue.compareTo(BigDecimal.ZERO) > 0 ?
                     new BigDecimal("100") : new BigDecimal("-100");
         }
 
         // 정확한 계산을 위해 높은 스케일 사용
-        return currentValue.subtract(yesterdayValue)
-                .divide(yesterdayValue.abs(), CALCULATION_SCALE, RoundingMode.HALF_UP)
+        return currentValue.subtract(yesterdayPremium)
+                .divide(yesterdayPremium.abs(), CALCULATION_SCALE, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100))
                 .setScale(DISPLAY_SCALE, RoundingMode.HALF_UP);
     }

--- a/src/main/java/_1danhebojo/coalarm/coalarm_service/global/config/AsyncConfig.java
+++ b/src/main/java/_1danhebojo/coalarm/coalarm_service/global/config/AsyncConfig.java
@@ -20,4 +20,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "kimchiTaskExecutor")
+    public Executor kimchiTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("Kimchi-Async-");
+        executor.initialize();
+        return executor;
+    }
 }


### PR DESCRIPTION
- 기존의 코드는 코인의 수 만큼 쿼리를 요청하여 N+1 문제 발생과 단일스레드로 계산하여 연산하는데 오랜 시간이 걸렸음
- 쿼리를 List형식으로 가져와 N+1 문제를 해결하였음
- List로 가져온 김치프리미엄의 필요한 모든 연산 데이터를ThreadPoolTaskExecutor를 통한 비동기 연산을 수행하여 연산 속도를 향상 시켰음